### PR TITLE
fix #4: escape special characters in constant strings

### DIFF
--- a/CoDLuaDecompiler.Decompiler/IR/Expression/Constant.cs
+++ b/CoDLuaDecompiler.Decompiler/IR/Expression/Constant.cs
@@ -1,9 +1,12 @@
 using CoDLuaDecompiler.Decompiler.IR.Identifiers;
+using System.Text;
 
 namespace CoDLuaDecompiler.Decompiler.IR.Expression
 {
     public class Constant : IExpression
     {
+        private static readonly StringBuilder constStringBuilder = new StringBuilder();
+
         public ValueType Type { get; set; }
         public double Number { get; set; }
         public string String { get; set; }
@@ -22,7 +25,23 @@ namespace CoDLuaDecompiler.Decompiler.IR.Expression
         public Constant(string str, int id)
         {
             Type = ValueType.String;
-            String = str.Replace("\n", "\\n");
+            for (int i = 0; i != str.Length; i++)
+            {
+                constStringBuilder.Append(str[i] switch
+                {
+                    '\0' => "\\0",
+                    '\a' => "\\a",
+                    '\t' => "\\t",
+                    '\n' => "\\n",
+                    '\v' => "\\v",
+                    '\r' => "\\r",
+                    '\\' => "\\\\",
+                    '"' => "\\\"",
+                    _ => str[i],
+                });
+            }
+            String = constStringBuilder.ToString();
+            constStringBuilder.Length = 0;
             Id = id;
         }
 


### PR DESCRIPTION
Worth noting that in the future, it may be desirable to move the StringBuilder instance to some utility class replicating the functionality of the StringBuilderCache viewable here:
https://referencesource.microsoft.com/#mscorlib/system/text/stringbuildercache.cs